### PR TITLE
Add Content-Type header to health server response

### DIFF
--- a/healthserver.go
+++ b/healthserver.go
@@ -63,6 +63,8 @@ func (hs *HealthServer) Start() error {
 		handler.HandleFunc("/"+endpoint.Name, func(response http.ResponseWriter, request *http.Request) {
 			errors := endpoint.Check()
 
+			response.Header().Add("Content-Type", "text/plain; charset=utf-8")
+
 			for _, err := range errors {
 				if err != nil {
 					response.WriteHeader(http.StatusServiceUnavailable)


### PR DESCRIPTION
Firefox complains about an unspecified charset. This is now fixed.